### PR TITLE
Changing event to listen to EVENT_LOAD_MODULE

### DIFF
--- a/src/ZendPhpDotEnv/Module.php
+++ b/src/ZendPhpDotEnv/Module.php
@@ -44,7 +44,7 @@ class Module
     {
         $events = $moduleManager->getEventManager();
 
-        $events->attach(ModuleEvent::EVENT_LOAD_MODULE, array($this, 'loadEnvironmentVariables'), 2000);
+        $events->attach(ModuleEvent::EVENT_LOAD_MODULE, array($this, 'loadEnvironmentVariables'), -1);
     }
 
     /**

--- a/src/ZendPhpDotEnv/Module.php
+++ b/src/ZendPhpDotEnv/Module.php
@@ -44,7 +44,7 @@ class Module
     {
         $events = $moduleManager->getEventManager();
 
-        $events->attach(ModuleEvent::EVENT_MERGE_CONFIG, array($this, 'loadEnvironmentVariables'), 2000);
+        $events->attach(ModuleEvent::EVENT_LOAD_MODULE, array($this, 'loadEnvironmentVariables'), 2000);
     }
 
     /**

--- a/tests/ZendPhpDotEnv/ModuleTest.php
+++ b/tests/ZendPhpDotEnv/ModuleTest.php
@@ -5,6 +5,7 @@ namespace AbacaphiliacTest\ZendPhpDotEnv;
 use Abacaphiliac\ZendPhpDotEnv\DotEnvLoader;
 use Abacaphiliac\ZendPhpDotEnv\Module;
 use Zend\EventManager\SharedEventManager;
+use Zend\ModuleManager\ModuleEvent;
 use Zend\Mvc\Service\EventManagerFactory;
 use Zend\Mvc\Service\ModuleManagerFactory;
 use Zend\ServiceManager\ServiceManager;
@@ -45,9 +46,9 @@ class ModuleTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Dotenv\Exception\InvalidPathException
+     * @expectedException \Abacaphiliac\ZendPhpDotEnv\Exception\InvalidWorkingDirectoryPathException
      */
-    public function testLoadModule()
+    public function testInitLoadsEnvironmentVariablesFromWorkingDirectory()
     {
         $serviceLocator = new ServiceManager();
         $serviceLocator->setService('ApplicationConfig', array(
@@ -59,10 +60,14 @@ class ModuleTest extends \PHPUnit_Framework_TestCase
         $serviceLocator->setFactory('EventManager', new EventManagerFactory());
         $serviceLocator->setService('SharedEventManager', new SharedEventManager());
         $serviceLocator->setFactory('ServiceListener', '\Zend\Mvc\Service\ServiceListenerFactory');
-        
+
         $moduleManagerFactory = new ModuleManagerFactory();
         $moduleManager = $moduleManagerFactory->createService($serviceLocator);
-        
-        $moduleManager->loadModules();
+
+        $module = new Module($constant = null, $variable = null, $file = '.testEnv');
+
+        $module->init($moduleManager);
+
+        $moduleManager->getEventManager()->trigger(new ModuleEvent(ModuleEvent::EVENT_LOAD_MODULE));
     }
 }


### PR DESCRIPTION
In my application, I cache the config, and the EVENT_MERGE_CONFIG is not being called every request. In order for me to rely on `getenv()` inside of application code, I need it loaded every request.
