### PR TITLE
add diagnostic checks to require or suggest .env file

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -19,7 +19,7 @@
     </target>
 
     <target name="phpcs">
-        <exec command="vendor/bin/phpcs --standard=PSR2 --extensions=php --severity=1 --colors -p src/ tests/"
+        <exec command="vendor/bin/phpcs --standard=PSR2 --extensions=php --severity=1 --colors -p config/ src/ tests/"
               passthru="true"
               output="/dev/stdout"
               error="/dev/stdout"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "vlucas/phpdotenv": "^2.2",
         "zendframework/zend-eventmanager": "^2",
         "zendframework/zend-modulemanager": "^2",
-        "zendframework/zend-servicemanager": "^2"
+        "zendframework/zend-servicemanager": "^2",
+        "zendframework/zend-stdlib": "^2"
     },
     "require-dev": {
         "phpunit/phpunit": "^5|^4",
@@ -29,7 +30,12 @@
         "zendframework/zend-mvc": "^2",
         "zendframework/zend-loader": "^2",
         "jakub-onderka/php-parallel-lint": "^0.9",
+        "zendframework/zenddiagnostics": "^1.0",
+        "mikey179/vfsStream": "^1.6",
         "squizlabs/php_codesniffer": "^2.2"
+    },
+    "suggest": {
+        "zendframework/zenddiagnostics": "Universal set of diagnostic tests for PHP applications."
     },
     "autoload": {
         "psr-4": {

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1,0 +1,26 @@
+<?php
+
+return array(
+    'service_manager' => array(
+        'factories' => array(
+            'Abacaphiliac\ZendPhpDotEnv\Diagnostics\RequireEnv' =>
+                'Abacaphiliac\ZendPhpDotEnv\Diagnostics\RequireEnvFactory',
+            'Abacaphiliac\ZendPhpDotEnv\Diagnostics\SuggestEnv' =>
+                'Abacaphiliac\ZendPhpDotEnv\Diagnostics\SuggestEnvFactory',
+        ),
+        'aliases' => array(
+            'Abacaphiliac\ZendPhpDotEnv\Diagnostics\CheckEnvFiles' =>
+                'Abacaphiliac\ZendPhpDotEnv\Diagnostics\SuggestEnv',
+        ),
+    ),
+    'diagnostics' => array(
+        'abacaphiliac/zend-phpdotenv' => array(
+            'Readable `.env` file(s)' => 'Abacaphiliac\ZendPhpDotEnv\Diagnostics\CheckEnvFiles',
+        ),
+    ),
+    'abacaphiliac/zend-phpdotenv' => array(
+        'files' => array(
+            'default' => getcwd() . '/.env',
+        ),
+    ),
+);

--- a/src/ZendPhpDotEnv/Diagnostics/RequireEnvFactory.php
+++ b/src/ZendPhpDotEnv/Diagnostics/RequireEnvFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Abacaphiliac\ZendPhpDotEnv\Diagnostics;
+
+use Abacaphiliac\ZendPhpDotEnv\Options\ModuleOptionsFactory;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class RequireEnvFactory implements FactoryInterface
+{
+    /**
+     * Create service
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     * @return RequireReadableFile
+     * @throws \InvalidArgumentException
+     * @throws \Zend\Stdlib\Exception\InvalidArgumentException
+     * @throws \Zend\ServiceManager\Exception\ServiceNotFoundException
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        $files = ModuleOptionsFactory::getFiles($serviceLocator);
+
+        return new RequireReadableFile($files);
+    }
+}

--- a/src/ZendPhpDotEnv/Diagnostics/RequireReadableFile.php
+++ b/src/ZendPhpDotEnv/Diagnostics/RequireReadableFile.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Abacaphiliac\ZendPhpDotEnv\Diagnostics;
+
+use ZendDiagnostics\Check\AbstractFileCheck;
+use ZendDiagnostics\Result\ResultInterface;
+use ZendDiagnostics\Result\Success;
+
+class RequireReadableFile extends AbstractFileCheck
+{
+    /**
+     * Validates a specific file type and returns a check result
+     *
+     * @param string $file
+     * @return ResultInterface
+     */
+    protected function validateFile($file)
+    {
+        // This is an optional secondary validation. The parent validates existence of the file.
+
+        return new Success();
+    }
+}

--- a/src/ZendPhpDotEnv/Diagnostics/SuggestEnvFactory.php
+++ b/src/ZendPhpDotEnv/Diagnostics/SuggestEnvFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Abacaphiliac\ZendPhpDotEnv\Diagnostics;
+
+use Abacaphiliac\ZendPhpDotEnv\Options\ModuleOptionsFactory;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class SuggestEnvFactory implements FactoryInterface
+{
+    /**
+     * Create service
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     * @return SuggestReadableFile
+     * @throws \Zend\Stdlib\Exception\InvalidArgumentException
+     * @throws \Zend\ServiceManager\Exception\ServiceNotFoundException
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        $files = ModuleOptionsFactory::getFiles($serviceLocator);
+
+        return new SuggestReadableFile($files);
+    }
+}

--- a/src/ZendPhpDotEnv/Diagnostics/SuggestReadableFile.php
+++ b/src/ZendPhpDotEnv/Diagnostics/SuggestReadableFile.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Abacaphiliac\ZendPhpDotEnv\Diagnostics;
+
+use ZendDiagnostics\Result\FailureInterface;
+use ZendDiagnostics\Result\ResultInterface;
+use ZendDiagnostics\Result\Warning;
+
+class SuggestReadableFile extends RequireReadableFile
+{
+    /**
+     * @return ResultInterface
+     */
+    public function check()
+    {
+        $result = parent::check();
+
+        if ($result instanceof FailureInterface) {
+            return new Warning($result->getMessage(), $result->getData());
+        }
+
+        return $result;
+    }
+}

--- a/src/ZendPhpDotEnv/Module.php
+++ b/src/ZendPhpDotEnv/Module.php
@@ -2,11 +2,12 @@
 
 namespace Abacaphiliac\ZendPhpDotEnv;
 
+use Zend\ModuleManager\Feature\ConfigProviderInterface;
 use Zend\ModuleManager\Feature\InitProviderInterface;
 use Zend\ModuleManager\ModuleEvent;
 use Zend\ModuleManager\ModuleManagerInterface;
 
-class Module implements InitProviderInterface
+class Module implements InitProviderInterface, ConfigProviderInterface
 {
     /** @var  string */
     private $constant = 'APPLICATION_PATH';
@@ -36,6 +37,16 @@ class Module implements InitProviderInterface
         if ($file) {
             $this->file = $file;
         }
+    }
+
+    /**
+     * Returns configuration to merge with application configuration
+     *
+     * @return array|\Traversable
+     */
+    public function getConfig()
+    {
+        return require __DIR__ . '/../../config/module.config.php';
     }
 
     /**

--- a/src/ZendPhpDotEnv/Options/ModuleOptions.php
+++ b/src/ZendPhpDotEnv/Options/ModuleOptions.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Abacaphiliac\ZendPhpDotEnv\Options;
+
+use Zend\Stdlib\AbstractOptions;
+
+class ModuleOptions extends AbstractOptions
+{
+    /** @var string[] */
+    private $files = array();
+
+    /**
+     * @return string[]
+     */
+    public function getFiles()
+    {
+        return $this->files;
+    }
+
+    /**
+     * @param string[] $files
+     * @return void
+     */
+    public function setFiles(array $files)
+    {
+        $this->files = $files;
+    }
+}

--- a/src/ZendPhpDotEnv/Options/ModuleOptionsFactory.php
+++ b/src/ZendPhpDotEnv/Options/ModuleOptionsFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Abacaphiliac\ZendPhpDotEnv\Options;
+
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class ModuleOptionsFactory implements FactoryInterface
+{
+    /**
+     * Create service
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     * @return ModuleOptions
+     * @throws \Zend\Stdlib\Exception\InvalidArgumentException
+     * @throws \Zend\ServiceManager\Exception\ServiceNotFoundException
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        $options = new ModuleOptions();
+
+        $config = $serviceLocator->get('config');
+
+        if (array_key_exists('abacaphiliac/zend-phpdotenv', $config)) {
+            $options->setFromArray($config['abacaphiliac/zend-phpdotenv']);
+        }
+
+        return $options;
+    }
+
+    /**
+     * @param ServiceLocatorInterface $serviceLocator
+     * @return string[]
+     * @throws \Zend\Stdlib\Exception\InvalidArgumentException
+     * @throws \Zend\ServiceManager\Exception\ServiceNotFoundException
+     */
+    public static function getFiles(ServiceLocatorInterface $serviceLocator)
+    {
+        $factory = new self;
+
+        $options = $factory->createService($serviceLocator);
+
+        return $options->getFiles();
+    }
+}

--- a/tests/ZendPhpDotEnv/Diagnostics/RequireEnvFactoryTest.php
+++ b/tests/ZendPhpDotEnv/Diagnostics/RequireEnvFactoryTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace AbacaphiliacTest\ZendPhpDotEnv\Diagnostics;
+
+use Abacaphiliac\ZendPhpDotEnv\Diagnostics\RequireEnvFactory;
+use Zend\ServiceManager\ServiceManager;
+
+/**
+ * @covers \Abacaphiliac\ZendPhpDotEnv\Diagnostics\RequireEnvFactory
+ */
+class RequireEnvFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var \ArrayObject */
+    private $config;
+
+    /** @var RequireEnvFactory */
+    private $sut;
+
+    /** @var ServiceManager */
+    private $serviceLocator;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->serviceLocator = new ServiceManager();
+        $this->serviceLocator->setService('config', $this->config = new \ArrayObject());
+
+        $this->sut = new RequireEnvFactory();
+    }
+
+    public function testCreateService()
+    {
+        $service = $this->sut->createService($this->serviceLocator);
+        self::assertInstanceOf('\Abacaphiliac\ZendPhpDotEnv\Diagnostics\RequireReadableFile', $service);
+    }
+}

--- a/tests/ZendPhpDotEnv/Diagnostics/RequireReadableFileTest.php
+++ b/tests/ZendPhpDotEnv/Diagnostics/RequireReadableFileTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace AbacaphiliacTest\ZendPhpDotEnv\Diagnostics;
+
+use Abacaphiliac\ZendPhpDotEnv\Diagnostics\RequireReadableFile;
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+use org\bovigo\vfs\vfsStreamFile;
+
+/**
+ * @covers \Abacaphiliac\ZendPhpDotEnv\Diagnostics\RequireReadableFile
+ */
+class RequireReadableFileTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var vfsStreamDirectory */
+    private $root;
+
+    /** @var vfsStreamFile */
+    private $file;
+
+    /** @var RequireReadableFile */
+    private $sut;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->root = vfsStream::setup('test');
+        $this->file = vfsStream::newFile('.env');
+        $this->root->addChild($this->file);
+
+        $this->sut = new RequireReadableFile(array(
+            $this->file->url(),
+        ));
+    }
+
+    public function testReadableFileIsValid()
+    {
+        $this->file->chmod(777);
+        $result = $this->sut->check();
+        self::assertInstanceOf('\ZendDiagnostics\Result\SuccessInterface', $result);
+    }
+
+    public function testDirectoryIsInvalid()
+    {
+        $sut = new RequireReadableFile(array(
+            $this->root->url(),
+        ));
+        $result = $sut->check();
+        self::assertInstanceOf('\ZendDiagnostics\Result\FailureInterface', $result);
+    }
+
+    public function testNonReadableFileIsInvalid()
+    {
+        $this->file->chmod(0);
+        $result = $this->sut->check();
+        self::assertInstanceOf('\ZendDiagnostics\Result\FailureInterface', $result);
+    }
+}

--- a/tests/ZendPhpDotEnv/Diagnostics/SuggestEnvFactoryTest.php
+++ b/tests/ZendPhpDotEnv/Diagnostics/SuggestEnvFactoryTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace AbacaphiliacTest\ZendPhpDotEnv\Diagnostics;
+
+use Abacaphiliac\ZendPhpDotEnv\Diagnostics\SuggestEnvFactory;
+use Zend\ServiceManager\ServiceManager;
+
+/**
+ * @covers \Abacaphiliac\ZendPhpDotEnv\Diagnostics\SuggestEnvFactory
+ */
+class SuggestEnvFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var \ArrayObject */
+    private $config;
+
+    /** @var SuggestEnvFactory */
+    private $sut;
+
+    /** @var ServiceManager */
+    private $serviceLocator;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->serviceLocator = new ServiceManager();
+        $this->serviceLocator->setService('config', $this->config = new \ArrayObject());
+
+        $this->sut = new SuggestEnvFactory();
+    }
+
+    public function testCreateService()
+    {
+        $service = $this->sut->createService($this->serviceLocator);
+        self::assertInstanceOf('\Abacaphiliac\ZendPhpDotEnv\Diagnostics\SuggestReadableFile', $service);
+    }
+}

--- a/tests/ZendPhpDotEnv/Diagnostics/SuggestReadableFileTest.php
+++ b/tests/ZendPhpDotEnv/Diagnostics/SuggestReadableFileTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace AbacaphiliacTest\ZendPhpDotEnv\Diagnostics;
+
+use Abacaphiliac\ZendPhpDotEnv\Diagnostics\SuggestReadableFile;
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+use org\bovigo\vfs\vfsStreamFile;
+
+/**
+ * @covers \Abacaphiliac\ZendPhpDotEnv\Diagnostics\SuggestReadableFile
+ */
+class SuggestReadableFileTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var vfsStreamDirectory */
+    private $root;
+
+    /** @var vfsStreamFile */
+    private $file;
+
+    /** @var SuggestReadableFile */
+    private $sut;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->root = vfsStream::setup('test');
+        $this->file = vfsStream::newFile('.env');
+        $this->root->addChild($this->file);
+
+        $this->sut = new SuggestReadableFile(array(
+            $this->file->url(),
+        ));
+    }
+
+    public function testReadableFileIsValid()
+    {
+        $this->file->chmod(777);
+        $result = $this->sut->check();
+        self::assertInstanceOf('\ZendDiagnostics\Result\SuccessInterface', $result);
+    }
+
+    public function testDirectoryIsInvalid()
+    {
+        $sut = new SuggestReadableFile(array(
+            $this->root->url(),
+        ));
+        $result = $sut->check();
+        self::assertInstanceOf('\ZendDiagnostics\Result\WarningInterface', $result);
+    }
+
+    public function testNonReadableFileIsInvalid()
+    {
+        $this->file->chmod(0);
+        $result = $this->sut->check();
+        self::assertInstanceOf('\ZendDiagnostics\Result\WarningInterface', $result);
+    }
+
+    public function testNonExistentFileIsInvalid()
+    {
+        self::assertFileExists($this->file->url());
+        unlink($this->file->url());
+        self::assertFileNotExists($this->file->url());
+
+        $result = $this->sut->check();
+        self::assertInstanceOf('\ZendDiagnostics\Result\WarningInterface', $result);
+    }
+}

--- a/tests/ZendPhpDotEnv/ModuleTest.php
+++ b/tests/ZendPhpDotEnv/ModuleTest.php
@@ -15,6 +15,13 @@ use Zend\ServiceManager\ServiceManager;
  */
 class ModuleTest extends \PHPUnit_Framework_TestCase
 {
+    public function testGetConfig()
+    {
+        $module = new Module();
+        $config = $module->getConfig();
+        self::assertArraySubset($config, unserialize(serialize($config)));
+    }
+
     /**
      * @expectedException \Abacaphiliac\ZendPhpDotEnv\Exception\InvalidConstantPathException
      */

--- a/tests/ZendPhpDotEnv/Options/ModuleOptionsFactoryTest.php
+++ b/tests/ZendPhpDotEnv/Options/ModuleOptionsFactoryTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace AbacaphiliacTest\ZendPhpDotEnv\Options;
+
+use Abacaphiliac\ZendPhpDotEnv\Options\ModuleOptionsFactory;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\ServiceManager\ServiceManager;
+
+/**
+ * @covers \Abacaphiliac\ZendPhpDotEnv\Options\ModuleOptionsFactory
+ */
+class ModuleOptionsFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var \ArrayObject */
+    private $config;
+
+    /** @var ServiceLocatorInterface */
+    private $serviceLocator;
+
+    /** @var ModuleOptionsFactory */
+    private $sut;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->serviceLocator = new ServiceManager();
+        $this->serviceLocator->setService('config', $this->config = new \ArrayObject());
+
+        $this->sut = new ModuleOptionsFactory();
+    }
+
+    public function testCreateService()
+    {
+        $actual = $this->sut->createService($this->serviceLocator);
+
+        self::assertInstanceOf('Abacaphiliac\ZendPhpDotEnv\Options\ModuleOptions', $actual);
+    }
+
+    public function testCreateServiceWithFiles()
+    {
+        $this->config['abacaphiliac/zend-phpdotenv'] = array(
+            'files' => $expected = array(
+                'relative/path/to/file',
+            ),
+        );
+
+        $actual = $this->sut->createService($this->serviceLocator);
+
+        self::assertInstanceOf('Abacaphiliac\ZendPhpDotEnv\Options\ModuleOptions', $actual);
+        self::assertArraySubset($expected, $actual->getFiles());
+    }
+
+    public function testGetFiles()
+    {
+        $this->config['abacaphiliac/zend-phpdotenv'] = array(
+            'files' => $expected = array(
+                'relative/path/to/file',
+            ),
+        );
+
+        self::assertArraySubset($expected, ModuleOptionsFactory::getFiles($this->serviceLocator));
+    }
+}

--- a/tests/ZendPhpDotEnv/Options/ModuleOptionsTest.php
+++ b/tests/ZendPhpDotEnv/Options/ModuleOptionsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace AbacaphiliacTest\ZendPhpDotEnv\Options;
+
+use Abacaphiliac\ZendPhpDotEnv\Options\ModuleOptions;
+
+/**
+ * @covers \Abacaphiliac\ZendPhpDotEnv\Options\ModuleOptions
+ */
+class ModuleOptionsTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var ModuleOptions */
+    private $sut;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->sut = new ModuleOptions();
+    }
+
+    public function testFiles()
+    {
+        self::assertCount(0, $this->sut->getFiles());
+
+        $this->sut->setFromArray(array(
+            'files' => $expected = array(
+                'relative/path/to/file',
+            ),
+        ));
+
+        self::assertArraySubset($expected, $this->sut->getFiles());
+    }
+}


### PR DESCRIPTION
add diagnostic checks to require .env file and to warn if file does not exist. default diagnostic requires the file, but the application can override to warn. applications can provide custom factories to override the .env filename and path.
